### PR TITLE
installation: fix invenio_base imports

### DIFF
--- a/examples/example_config.txt
+++ b/examples/example_config.txt
@@ -1,4 +1,4 @@
-from invenio.base.config import PACKAGES as _PACKAGES
+from invenio_base.config import PACKAGES as _PACKAGES
 
 PACKAGES = ['samplepkg', 'invenio_jsonschemas'] + _PACKAGES
 JSONSCHEMAS_BASE_SCHEMA = 'base/record-0.1.json'

--- a/invenio_jsonschemas/bundles.py
+++ b/invenio_jsonschemas/bundles.py
@@ -26,7 +26,7 @@
 
 from __future__ import unicode_literals
 
-from invenio.base.bundles import invenio as _invenio_js, \
+from invenio_base.bundles import invenio as _invenio_js, \
     jquery as _j
 from invenio.ext.assets import Bundle, RequireJSFilter
 

--- a/requirements-devel.txt
+++ b/requirements-devel.txt
@@ -21,3 +21,5 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+-e git+git://github.com/inveniosoftware/invenio-base.git#egg=invenio-base

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ requirements = [
     'jsonschema>=2.5.0',
     'six>=1.7.2',
     'speaklater>=1.3',
+    'invenio-base>=0.2.1',
 ]
 
 test_requirements = [


### PR DESCRIPTION
- FIX Adds missing `invenio_base` dependency and amends past
  upgrade recipes following its separation into standalone package.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
