### PR TITLE
tests: fix incompatibility with pytest>=2.8.0

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,7 @@
 include *.py
 include *.rst
 include LICENSE
-include babel.ini
+include babel.ini pytest.ini
 include requirements*.txt
 
 exclude *.yml

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
 
 [pytest]
-addopts = --clearcache --pep8 --ignore=docs --cov=invenio_jsonschemas --cov-report=term-missing
+addopts = --pep8 --ignore=docs --cov=invenio_jsonschemas --cov-report=term-missing
 pep8ignore =
     tests/* ALL
 

--- a/setup.py
+++ b/setup.py
@@ -47,10 +47,10 @@ requirements = [
 ]
 
 test_requirements = [
-    'coverage>=3.7.1',
-    'pytest-cov>=1.8.0',
+    'coverage>=4.0.0',
+    'pytest-cov>=2.1.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.7.0',
+    'pytest>=2.8.0',
 ]
 
 
@@ -82,9 +82,6 @@ class PyTest(TestCommand):
         """Run tests."""
         # import here, cause outside the eggs aren't loaded
         import pytest
-        import _pytest.config
-        pm = _pytest.config.get_plugin_manager()
-        pm.consider_setuptools_entrypoints()
         errno = pytest.main(self.pytest_args)
         sys.exit(errno)
 


### PR DESCRIPTION
- FIX Removes calls to PluginManager
  consider_setuptools_entrypoints() removed in PyTest 2.8.0.

Signed-off-by: Sami Hiltunen sami.mikael.hiltunen@cern.ch
