### PR TITLE
installation: entry point fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,6 +124,9 @@ setup(
         'invenio_base.apps': [
             'invenio_jsonschemas = invenio_jsonschemas:InvenioJSONSchemas',
         ],
+        'invenio_base.api_apps': [
+            'invenio_jsonschemas = invenio_jsonschemas:InvenioJSONSchemas',
+        ],
         'invenio_records.jsonresolver': [
             'invenio_jsonschemas = invenio_jsonschemas.jsonresolver',
         ]


### PR DESCRIPTION
- Installs extension on API application as the JSON resolver does not
  work without the configuration variables defined, causing Records
  JSONRef replacement to fail.

Signed-off-by: Lars Holm Nielsen lars.holm.nielsen@cern.ch
