### PR TITLE
ext: warning depending on JSONSCHEMAS_HOST

### DIFF
--- a/invenio_jsonschemas/ext.py
+++ b/invenio_jsonschemas/ext.py
@@ -233,6 +233,11 @@ class InvenioJSONSchemas(object):
             if k.startswith('JSONSCHEMAS_'):
                 app.config.setdefault(k, getattr(config, k))
 
+        host_setting = app.config['JSONSCHEMAS_HOST']
+        if not host_setting or host_setting == 'localhost':
+            print('WARNING: JSONSCHEMAS_HOST is set to {}'.format(
+                host_setting))
+
     def __getattr__(self, name):
         """Proxy to state object."""
         return getattr(self._state, name, None)

--- a/invenio_jsonschemas/ext.py
+++ b/invenio_jsonschemas/ext.py
@@ -235,7 +235,7 @@ class InvenioJSONSchemas(object):
 
         host_setting = app.config['JSONSCHEMAS_HOST']
         if not host_setting or host_setting == 'localhost':
-            print('WARNING: JSONSCHEMAS_HOST is set to {}'.format(
+            app.logger.warning('JSONSCHEMAS_HOST is set to {0}'.format(
                 host_setting))
 
     def __getattr__(self, name):


### PR DESCRIPTION
- Prints a warning if it is not set or set to localhost.
  (closes #33)
## 

This should be fine for now, but could in future be delegated to a logging system to manage different outputs (stdout, stderr, syslog, logfiles, emails, etc.) and also severity levels.
