### PR TITLE
ext: use init_config before init_app

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,7 +25,7 @@
 Changes
 =======
 
-Version 1.0.0a6 (release 2017-10-20)
+Version 1.0.0a7 (release 2017-10-23)
 ------------------------------------
 
 - Initial public release.

--- a/RELEASE-NOTES.rst
+++ b/RELEASE-NOTES.rst
@@ -1,8 +1,8 @@
 ==============================
- Invenio-JSONSchemas v1.0.0a6
+ Invenio-JSONSchemas v1.0.0a7
 ==============================
 
-Invenio-JSONSchemas v1.0.0a6 was released on October 10, 2017.
+Invenio-JSONSchemas v1.0.0a7 was released on October 23, 2017.
 
 About
 -----
@@ -19,7 +19,7 @@ What's new
 Installation
 ------------
 
-   $ pip install invenio-jsonschemas==1.0.0a6
+   $ pip install invenio-jsonschemas==1.0.0a7
 
 Documentation
 -------------

--- a/invenio_jsonschemas/ext.py
+++ b/invenio_jsonschemas/ext.py
@@ -218,12 +218,16 @@ class InvenioJSONSchemas(object):
         if app:
             self.init_app(app, **kwargs)
 
-    def init_app(self, app, entry_point_group=None, register_blueprint=True):
+    def init_app(self, app, entry_point_group=None, register_blueprint=True,
+                 register_config_blueprint=None):
         """Flask application initialization.
 
         :param app: The Flask application.
         :param entry_point_group: The group entry point to load extensions.
             (Default: ``invenio_jsonschemas.schemas``)
+        :param register_blueprint: Register the blueprints.
+        :param register_config_blueprint: Register blueprint for the specific
+            app from a config variable.
         """
         self.init_config(app)
 
@@ -240,6 +244,11 @@ class InvenioJSONSchemas(object):
                     entry_point_group):
                 directory = os.path.dirname(base_entry.load().__file__)
                 state.register_schemas_dir(directory)
+
+        # Init blueprints
+        _register_blueprint = app.config.get(register_config_blueprint)
+        if _register_blueprint is not None:
+            register_blueprint = _register_blueprint
 
         if register_blueprint:
             app.register_blueprint(
@@ -276,7 +285,7 @@ class InvenioJSONSchemasUI(InvenioJSONSchemas):
         """
         return super(InvenioJSONSchemasUI, self).init_app(
             app,
-            register_blueprint=app.config['JSONSCHEMAS_REGISTER_ENDPOINTS_UI']
+            register_config_blueprint='JSONSCHEMAS_REGISTER_ENDPOINTS_UI'
         )
 
 
@@ -290,5 +299,5 @@ class InvenioJSONSchemasAPI(InvenioJSONSchemas):
         """
         return super(InvenioJSONSchemasAPI, self).init_app(
             app,
-            register_blueprint=app.config['JSONSCHEMAS_REGISTER_ENDPOINTS_API']
+            register_config_blueprint='JSONSCHEMAS_REGISTER_ENDPOINTS_API'
         )

--- a/invenio_jsonschemas/version.py
+++ b/invenio_jsonschemas/version.py
@@ -30,4 +30,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = "1.0.0a6"
+__version__ = "1.0.0a7"


### PR DESCRIPTION
Initialize app's config before calling supertype's init_app (addresses #65).

Signed-off-by: Chris Aslanoglou <chris.aslanoglou@gmail.com>