### PR TITLE
ext: only register whitelisted schema entries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.0.1 (released 2019-09-04)
+
+- Adds config ``JSONSCHEMAS_SCHEMAS`` to whitelist entrypoint names
+
 Version 1.0.0 (released 2018-03-23)
 
 - Initial public release.

--- a/invenio_jsonschemas/config.py
+++ b/invenio_jsonschemas/config.py
@@ -44,3 +44,25 @@ JSONSCHEMAS_REGISTER_ENDPOINTS_API = True
 
 JSONSCHEMAS_REGISTER_ENDPOINTS_UI = True
 """Register the endpoints on the UI app."""
+
+JSONSCHEMAS_SCHEMAS = None  # loads all JSON Schemas
+"""List of entrypoint names to register JSON Schemas for.
+
+If `None`, all JSON Schemas defined through the ``invenio_jsonschemas.schemas``
+entry point in setup.py will be registered.
+If ``[]``, no JSON Schemas will be registered.
+
+For example, if you only want to register `foo` and skip `bar` schemas:
+
+.. code-block:: python
+
+    # in your `setup.py` you would specify:
+    entry_points={
+        'invenio_jsonschemas.schemas': [
+            'foo = invenio_foo.schemas',
+            'bar = invenio_bar.schemas',
+        ],
+    }
+    # and in your config.py
+    JSONSCHEMAS_SCHEMAS = ['foo']
+"""

--- a/invenio_jsonschemas/ext.py
+++ b/invenio_jsonschemas/ext.py
@@ -224,10 +224,13 @@ class InvenioJSONSchemas(object):
 
         # Load the json-schemas from extension points.
         if entry_point_group:
+            whitelisted_entries = app.config['JSONSCHEMAS_SCHEMAS']
             for base_entry in pkg_resources.iter_entry_points(
                     entry_point_group):
-                directory = os.path.dirname(base_entry.load().__file__)
-                state.register_schemas_dir(directory)
+                if whitelisted_entries is None or \
+                        base_entry.name in whitelisted_entries:
+                    directory = os.path.dirname(base_entry.load().__file__)
+                    state.register_schemas_dir(directory)
 
         # Init blueprints
         _register_blueprint = app.config.get(register_config_blueprint)

--- a/invenio_jsonschemas/version.py
+++ b/invenio_jsonschemas/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.0.0'
+__version__ = '1.0.1'


### PR DESCRIPTION
* Added new config `JSONSCHEMAS_SCHEMAS` used to whitelist entry names defined in `invenio_jsonschemas.schemas`
* By default, all schemas will be registered so the default behavior remains unchanged