### PR TITLE
ext: build local ref resolver store

### DIFF
--- a/invenio_jsonschemas/config.py
+++ b/invenio_jsonschemas/config.py
@@ -66,3 +66,6 @@ For example, if you only want to register `foo` and skip `bar` schemas:
     # and in your config.py
     JSONSCHEMAS_SCHEMAS = ['foo']
 """
+
+JSONSCHEMAS_LOCAL_REFRESOLVER_URI_SCHEME = "local://"
+"""Non-standard URI scheme to reference local schemas."""

--- a/invenio_jsonschemas/proxies.py
+++ b/invenio_jsonschemas/proxies.py
@@ -17,3 +17,8 @@ current_jsonschemas = LocalProxy(
     lambda: current_app.extensions['invenio-jsonschemas']
 )
 """Helper proxy to access state object."""
+
+current_refresolver_store = LocalProxy(
+    lambda: current_app.extensions['invenio-jsonschemas'].refresolver_store()
+)
+"""Current JSONSchema ref resolver store."""

--- a/tests/test_invenio_jsonschemas.py
+++ b/tests/test_invenio_jsonschemas.py
@@ -455,3 +455,16 @@ def test_resolve_schema():
             'species_nested': {'type': 'string'}},
         'type': 'object'}
     assert resolve_schema(test_schema) == resolved_schema
+
+
+def test_export_refresolver_store(app, dir_factory):
+    """Test export local ref resolver store."""
+    ext = InvenioJSONSchemas(app, entry_point_group=None)
+    schema_files = build_schemas(1)
+    with dir_factory(schema_files) as directory:
+        for schema in schema_files.keys():
+            ext.register_schema(directory, schema)
+
+        for schema in ext.refresolver_store():
+            assert schema.startswith(
+                app.config.get("JSONSCHEMAS_LOCAL_REFRESOLVER_URI_SCHEME"))


### PR DESCRIPTION
Closes inveniosoftware/invenio-rdm-records#356.

**Progress:**
  - [x] Add support for exporting the registry with ``local://`` schema through `InvenioJSONSchemasState.refresolver_store`
  - [x] Add validation of if ``$id`` matches the registry key.
      - [x] Clarify what kind of values will `self.schemas` have as keys. Tests have strings however Invenio-Records tests have dicts (the schema itself already loaded)


An integration test can be run locally:
- At Invenio-RDM-Records level: https://github.com/inveniosoftware/invenio-rdm-records/pull/492