### PR TITLE
errors: fix string interpolation and release

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.1.3 (released 2021-06-17)
+
+- Fix string interpolation on error messages.
+
 Version 1.1.2 (released 2021-04-06)
 
 - Adds method to build a ref resolver store from the registry with a local

--- a/invenio_jsonschemas/errors.py
+++ b/invenio_jsonschemas/errors.py
@@ -25,7 +25,7 @@ class JSONSchemaNotFound(JSONSchemaError):
         """
         self.schema = schema
         super(JSONSchemaNotFound, self).__init__(
-            'Schema "{}" not found'.format(schema), *args, **kwargs
+            "Schema {schema} not found".format(schema=schema), *args, **kwargs
         )
 
 
@@ -41,9 +41,8 @@ class JSONSchemaDuplicate(JSONSchemaError):
         """
         self.schema = schema
         super(JSONSchemaDuplicate, self).__init__(
-            'Schema "{schema}" defined in multiple ' +
-            'directories: "{first}" and "{second}"'.format(
-                schema=schema,
+            "Schema {schema} defined in multiple ".format(schema=schema) +
+            "directories: {first} and {second}".format(
                 first=first_dir,
                 second=second_dir),
             *args, **kwargs)

--- a/invenio_jsonschemas/version.py
+++ b/invenio_jsonschemas/version.py
@@ -14,4 +14,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.2'
+__version__ = '1.1.3'


### PR DESCRIPTION
It was being displayed wrongly, e.g.:

```
 invenio_jsonschemas.errors.JSONSchemaDuplicate: Schema "{schema}" defined in multiple directories: "/Users/ppanero/Workspace/inveniosw/invenio-vocabularies/invenio_vocabularies/records/jsonschemas" and "/Users/ppanero/Workspace/inveniosw/invenio-vocabularies/invenio_vocabularies/records/jsonschemas"
```

Now it displays the correct value (not the variable name):

```
  invenio_jsonschemas.errors.JSONSchemaDuplicate: Schema vocabularies/vocabulary-v1.0.0.json defined in multiple directories: /Users/ppanero/Workspace/inveniosw/invenio-vocabularies/invenio_vocabularies/records/jsonschemas and /Users/ppanero/Workspace/inveniosw/invenio-vocabularies/invenio_vocabularies/records/jsonschemas
 ```